### PR TITLE
Add X-Hostname header to pass hostname in header.

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		fmt.Fprintln(w, err)
 	}
-
+	w.Header().Set("X-Hostname", config.Hostname)
 	fmt.Fprint(w, data)
 }
 


### PR DESCRIPTION
Useful for checking with `curl -I ...`

Sometimes I just want to check the service status from curl. And the html output is messy for terminal. So I use `curl -I` to see the headers only. and this PR will set a header `X-Hostname` to output as header.